### PR TITLE
🎨 Palette: Improve Cart focus management

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -17,3 +17,7 @@
 ## 2026-05-23 - Refactoring Dropdowns to Semantic HTML
 **Learning:** Changing dropdown items from `<div>` to `<a>` for accessibility requires careful auditing of CSS selectors. Generic selectors like `.parent > div div` will often break or misapply styles when one layer changes type.
 **Action:** When refactoring for semantics, grep for the class names or parent selectors in CSS to identify fragile descendant combinators that need updating to include the new element type (e.g., `.parent > div a`).
+
+## 2026-05-24 - Focus Management in Lists
+**Learning:** When removing items from a list that triggers a re-render, keyboard focus is typically lost (reset to body), causing disorientation for keyboard and screen reader users.
+**Action:** Always capture the intended focus index (current or previous) before re-rendering, and explicitly call `.focus()` on the corresponding new element after the DOM update.

--- a/scripts/cart.js
+++ b/scripts/cart.js
@@ -96,8 +96,29 @@ function removeItem(index)
 {
     cart.splice(index,1);
     localStorage.setItem("cartItems",JSON.stringify(cart));
+
+    // 🎨 Palette: Calculate focus target before re-render
+    // If we remove the last item, focus the previous one.
+    // Otherwise focus the item taking the removed item's place (same index).
+    const focusIndex = Math.min(index, cart.length - 1);
+
     display(cart);
     displayTotal();
+
+    // 🎨 Palette: Restore focus to prevent context loss for keyboard users
+    if (cart.length > 0) {
+        const buttons = document.querySelectorAll('.remove-btn');
+        if (buttons[focusIndex]) {
+            buttons[focusIndex].focus();
+        }
+    } else {
+        // If cart is empty, focus the "Start Shopping" button
+        // Note: display() creates this button with id "check_out" in the empty state
+        const shopBtn = document.querySelector("#left #check_out");
+        if (shopBtn) {
+            shopBtn.focus();
+        }
+    }
 }
 
 function displayTotal()


### PR DESCRIPTION
Implemented focus restoration logic in `scripts/cart.js`. When a user removes an item, the script now calculates the index of the item that should receive focus (either the item taking the place of the removed one, or the previous one if the last item was removed) and programmatically sets focus to it after the cart is re-rendered. This prevents the focus from being reset to the start of the document, which is a significant accessibility barrier.

---
*PR created automatically by Jules for task [11791387118298195200](https://jules.google.com/task/11791387118298195200) started by @Shubhamvumap123*