### PR TITLE
🎨 Palette: Refactor furniture page banners for accessibility

### DIFF
--- a/furniture.html
+++ b/furniture.html
@@ -67,28 +67,32 @@
         </ul>
       </div>
       <div id="furniture-images">
-        <div
+        <a
+          href="livingRoom.html"
           class="furniture-Img1"
-          onclick="window.location.href='livingRoom.html'"
+          style="display: block; margin-top: 0;"
         >
           <div class="text">
             <span>extra <br />15% off </span><br />Select furniture* <br />
-            <button id="readMore">Shop Now</button>
+            <span id="readMore" class="readMore" style="display: inline-block; text-align: center; margin-top: 10%;">Shop Now</span>
           </div>
           <img
             id="img2"
+            alt="Living room furniture setting"
             src="https://ak1.ostkcdn.com/img/mxc/12202021_WINTER2022_FURNITURE_Hero_Desktop.jpg"
           />
-        </div>
-        <div
+        </a>
+        <a
+          href="livingRoom.html"
           class="furniture-Img2"
-          onclick="window.location.href='livingRoom.html'"
+          style="margin-top: 0;"
         >
           <div>
             <div class="furniture-Img1text">
               Top Rated <span><br />Coffee Tables</span>
             </div>
             <img
+              alt="Top Rated Coffee Tables"
               src="https://ak1.ostkcdn.com/img/mxc/12202021_WINTER2022_FURNITURE_MM_01.png?imwidth=320&impolicy=medium?imwidth=384"
               id="img1"
             />
@@ -98,11 +102,12 @@
               Counter Height <span><br />Bar Stools</span>
             </div>
             <img
+              alt="Counter Height Bar Stools"
               src="https://ak1.ostkcdn.com/img/mxc/12202021_WINTER2022_FURNITURE_MM_02.png?imwidth=320&impolicy=medium?imwidth=384"
               id="img1"
             />
           </div>
-        </div>
+        </a>
       </div>
     </div>
     <p class="txtSize">Popular Furniture Categories</p>


### PR DESCRIPTION
💡 What: Refactored the main promotional banners in furniture.html to use semantic <a> tags instead of clickable divs. Added missing alt text to images. Replaced the nested button with a styled span to maintain validity.
🎯 Why: Using div elements with onclick handlers for navigation breaks keyboard accessibility and is an anti-pattern. Native links ensure proper tab order and screen reader support.
♿ Accessibility: Banners are now focusable and navigable via keyboard. Images now have descriptive alt text.

---
*PR created automatically by Jules for task [5996332953139293646](https://jules.google.com/task/5996332953139293646) started by @Shubhamvumap123*