### PR TITLE
⚡ Bolt: Optimize product fetch with Mongoose .lean()

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -13,3 +13,7 @@
 ## 2026-01-23 - [Pattern: Duplicate IDs in Loop]
 **Learning:** `scripts/cart.js` created elements with `id="remove"` and `id="name"` inside a loop, resulting in invalid HTML and potential selector issues.
 **Action:** Use classes (e.g., `.remove-btn`, `.item-name`) for repeated elements. Use event delegation for interactions on these elements.
+
+## 2026-01-30 - [Pattern: Mongoose Hydration Overhead]
+**Learning:** `Product.find()` was used in `Authentication/src/controllers/product.controller.js` without `.lean()`, causing full Mongoose document hydration for read-only data.
+**Action:** Always use `.lean()` for read-only Mongoose queries to return POJOs, significantly reducing memory usage and serialization time.

--- a/Authentication/src/controllers/product.controller.js
+++ b/Authentication/src/controllers/product.controller.js
@@ -5,8 +5,7 @@ const router = express.Router();
 const authenticate = require("../middlewares/authenticate")
 const Product = require("../models/product.model")
 
-router.post("", authenticate, async (req, res) => {
-
+const createProduct = async (req, res) => {
     req.body.user_id = req.userID;
     try{
         const product = await Product.create(req.body)
@@ -15,17 +14,24 @@ router.post("", authenticate, async (req, res) => {
     catch(err){
         return res.status(400).send({message : err.message})
     }
- 
-})
+}
 
-router.get("", async (req, res) => {
+const getProducts = async (req, res) => {
     try{
-        const product = await Product.find()
+        // ⚡ Bolt Optimization: Added .lean() to return POJOs instead of Mongoose Documents.
+        // This avoids the overhead of hydrating full Mongoose instances for read-only data.
+        const product = await Product.find().lean()
         return res.status(200).send(product)
     }
     catch(err){
         return res.status(400).send({message : err.message})
     }
-})
+}
+
+router.post("", authenticate, createProduct)
+
+router.get("", getProducts)
 
 module.exports = router;
+module.exports.createProduct = createProduct;
+module.exports.getProducts = getProducts;

--- a/Authentication/tests/product.controller.test.js
+++ b/Authentication/tests/product.controller.test.js
@@ -1,0 +1,37 @@
+
+const productController = require('../src/controllers/product.controller');
+const Product = require('../src/models/product.model');
+const httpMocks = require('node-mocks-http');
+
+jest.mock('../src/models/product.model');
+
+describe('Product Controller', () => {
+    let req, res;
+
+    beforeEach(() => {
+        req = httpMocks.createRequest();
+        res = httpMocks.createResponse();
+        jest.clearAllMocks();
+    });
+
+    describe('getProducts', () => {
+        it('should call .lean() for performance and return products', async () => {
+             const mockProducts = [{ title: 'P1', price: 100 }, { title: 'P2', price: 200 }];
+
+             const mockChain = {
+                 lean: jest.fn().mockResolvedValue(mockProducts)
+             };
+
+             Product.find.mockReturnValue(mockChain);
+
+             await productController.getProducts(req, res);
+
+             expect(Product.find).toHaveBeenCalled();
+             expect(mockChain.lean).toHaveBeenCalled();
+
+             expect(res.statusCode).toBe(200);
+             // Verify the data sent is the mockProducts (which comes from lean())
+             expect(res._getData()).toEqual(mockProducts);
+        });
+    });
+});


### PR DESCRIPTION
💡 What:
Implemented `.lean()` on the `Product.find()` query in the `getProducts` controller. This instructs Mongoose to return Plain Old JavaScript Objects (POJOs) instead of fully hydrated Mongoose Documents.

🎯 Why:
The `getProducts` endpoint is a read-only operation. Hydrating Mongoose documents adds significant overhead (memory and CPU) for internal tracking, getters/setters, and methods that are not needed for a simple API response. This optimization reduces the memory footprint and speeds up serialization.

📊 Impact:
- Reduces memory usage for the products array.
- Speeds up the query execution and JSON serialization.
- Verified via unit test that explicitly checks for the `.lean()` call.

🔬 Measurement:
Run `npm test` in the `Authentication` directory. The test `tests/product.controller.test.js` verifies that `.lean()` is called.

---
*PR created automatically by Jules for task [16588916015513679678](https://jules.google.com/task/16588916015513679678) started by @Shubhamvumap123*