### PR TITLE
Enable GitHub Auto-merge Workflow

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,0 +1,17 @@
+name: Enable auto-merge
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  enable-auto-merge:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Enable auto-merge
+        run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Added a GitHub Actions workflow to automatically enable auto-merge for new pull requests. This helps streamline the development process by removing the need to manually enable auto-merge for each PR. The workflow runs when a PR is opened and uses the `gh pr merge --auto --merge` command.

---
*PR created automatically by Jules for task [2275910539552794770](https://jules.google.com/task/2275910539552794770) started by @Shubhamvumap123*